### PR TITLE
Add  Categories and Provincies Taxonomy Vocabularies

### DIFF
--- a/config/sync/core.base_field_override.block_content.basic.changed.yml
+++ b/config/sync/core.base_field_override.block_content.basic.changed.yml
@@ -1,0 +1,18 @@
+uuid: 047cc173-813d-4a92-9ddd-1e5b7cb72847
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.basic
+id: block_content.basic.changed
+field_name: changed
+entity_type: block_content
+bundle: basic
+label: Changed
+description: 'The time that the content block was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/sync/core.base_field_override.block_content.basic.info.yml
+++ b/config/sync/core.base_field_override.block_content.basic.info.yml
@@ -1,0 +1,18 @@
+uuid: 5d05c2a4-734d-43a5-aa4d-765e3ad514fb
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.basic
+id: block_content.basic.info
+field_name: info
+entity_type: block_content
+bundle: basic
+label: 'Block description'
+description: 'A brief description of your block.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/core.base_field_override.block_content.basic.status.yml
+++ b/config/sync/core.base_field_override.block_content.basic.status.yml
@@ -1,0 +1,22 @@
+uuid: 41a33cc1-ee43-4833-9341-adc194ac9623
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.basic
+id: block_content.basic.status
+field_name: status
+entity_type: block_content
+bundle: basic
+label: Published
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/core.base_field_override.comment.comment.changed.yml
+++ b/config/sync/core.base_field_override.comment.comment.changed.yml
@@ -1,0 +1,18 @@
+uuid: 6e131a33-7177-4074-a6ad-99890becb54d
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.comment
+id: comment.comment.changed
+field_name: changed
+entity_type: comment
+bundle: comment
+label: Changed
+description: 'The time that the comment was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/sync/core.base_field_override.comment.comment.created.yml
+++ b/config/sync/core.base_field_override.comment.comment.created.yml
@@ -1,0 +1,18 @@
+uuid: d73f3f0b-2fb1-4d80-bafb-caa255523d14
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.comment
+id: comment.comment.created
+field_name: created
+entity_type: comment
+bundle: comment
+label: Created
+description: 'The time that the comment was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/config/sync/core.base_field_override.comment.comment.homepage.yml
+++ b/config/sync/core.base_field_override.comment.comment.homepage.yml
@@ -1,0 +1,18 @@
+uuid: 80fe3a30-0d31-4aae-ad38-2be81b35a6c9
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.comment
+id: comment.comment.homepage
+field_name: homepage
+entity_type: comment
+bundle: comment
+label: Homepage
+description: "The comment author's home page address."
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: uri

--- a/config/sync/core.base_field_override.comment.comment.hostname.yml
+++ b/config/sync/core.base_field_override.comment.comment.hostname.yml
@@ -1,0 +1,18 @@
+uuid: 65d2a0a5-c020-426c-97e0-3cb72b783dd2
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.comment
+id: comment.comment.hostname
+field_name: hostname
+entity_type: comment
+bundle: comment
+label: Hostname
+description: "The comment author's hostname."
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\comment\Entity\Comment::getDefaultHostname'
+settings: {  }
+field_type: string

--- a/config/sync/core.base_field_override.comment.comment.mail.yml
+++ b/config/sync/core.base_field_override.comment.comment.mail.yml
@@ -1,0 +1,18 @@
+uuid: 2abc5895-c7bc-4c6a-800a-ee460a030992
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.comment
+id: comment.comment.mail
+field_name: mail
+entity_type: comment
+bundle: comment
+label: Email
+description: "The comment author's email address."
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: email

--- a/config/sync/core.base_field_override.comment.comment.name.yml
+++ b/config/sync/core.base_field_override.comment.comment.name.yml
@@ -1,0 +1,20 @@
+uuid: 492feea3-5d63-43ca-9088-c089bf51b6f7
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.comment
+id: comment.comment.name
+field_name: name
+entity_type: comment
+bundle: comment
+label: Name
+description: "The comment author's name."
+required: false
+translatable: false
+default_value:
+  -
+    value: ''
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/core.base_field_override.comment.comment.status.yml
+++ b/config/sync/core.base_field_override.comment.comment.status.yml
@@ -1,0 +1,22 @@
+uuid: 560bcad3-4ceb-48dc-8026-42cf3d1a0d46
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.comment
+id: comment.comment.status
+field_name: status
+entity_type: comment
+bundle: comment
+label: Published
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: 'Drupal\comment\Entity\Comment::getDefaultStatus'
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/core.base_field_override.comment.comment.subject.yml
+++ b/config/sync/core.base_field_override.comment.comment.subject.yml
@@ -1,0 +1,18 @@
+uuid: eee2b18c-496d-484c-bcad-94651579ff85
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.comment
+id: comment.comment.subject
+field_name: subject
+entity_type: comment
+bundle: comment
+label: Subject
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/core.base_field_override.comment.comment.uid.yml
+++ b/config/sync/core.base_field_override.comment.comment.uid.yml
@@ -1,0 +1,20 @@
+uuid: e23902b0-b9d7-4047-bace-dc28a4e0a1c7
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.comment
+id: comment.comment.uid
+field_name: uid
+entity_type: comment
+bundle: comment
+label: 'User ID'
+description: 'The user ID of the comment author.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\comment\Entity\Comment::getDefaultEntityOwner'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/sync/core.base_field_override.menu_link_content.menu_link_content.changed.yml
+++ b/config/sync/core.base_field_override.menu_link_content.menu_link_content.changed.yml
@@ -1,0 +1,18 @@
+uuid: 2ee089b5-8a59-421e-8ae9-e09049d71a9d
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_link_content
+id: menu_link_content.menu_link_content.changed
+field_name: changed
+entity_type: menu_link_content
+bundle: menu_link_content
+label: Changed
+description: 'The time that the menu link was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/sync/core.base_field_override.menu_link_content.menu_link_content.description.yml
+++ b/config/sync/core.base_field_override.menu_link_content.menu_link_content.description.yml
@@ -1,0 +1,18 @@
+uuid: 3134a45f-ed08-41d6-a99a-1dfa5bb26db1
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_link_content
+id: menu_link_content.menu_link_content.description
+field_name: description
+entity_type: menu_link_content
+bundle: menu_link_content
+label: Description
+description: 'Shown when hovering over the menu link.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/core.base_field_override.menu_link_content.menu_link_content.title.yml
+++ b/config/sync/core.base_field_override.menu_link_content.menu_link_content.title.yml
@@ -1,0 +1,18 @@
+uuid: ddc1becc-a73f-418b-abe5-6133469bccbd
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_link_content
+id: menu_link_content.menu_link_content.title
+field_name: title
+entity_type: menu_link_content
+bundle: menu_link_content
+label: 'Menu link title'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/core.base_field_override.node.article.changed.yml
+++ b/config/sync/core.base_field_override.node.article.changed.yml
@@ -1,0 +1,18 @@
+uuid: 374c0b2c-3e72-4781-b11f-ad3cd8a5eb6f
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.article
+id: node.article.changed
+field_name: changed
+entity_type: node
+bundle: article
+label: Changed
+description: 'The time that the node was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/sync/core.base_field_override.node.article.created.yml
+++ b/config/sync/core.base_field_override.node.article.created.yml
@@ -1,0 +1,18 @@
+uuid: bb12c7ae-adc3-465d-a085-9755d11227b5
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.article
+id: node.article.created
+field_name: created
+entity_type: node
+bundle: article
+label: 'Authored on'
+description: 'The date and time that the content was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/config/sync/core.base_field_override.node.article.path.yml
+++ b/config/sync/core.base_field_override.node.article.path.yml
@@ -1,0 +1,20 @@
+uuid: 487df367-64bc-4b47-9821-92eda2dd6180
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.article
+  module:
+    - path
+id: node.article.path
+field_name: path
+entity_type: node
+bundle: article
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/config/sync/core.base_field_override.node.article.promote.yml
+++ b/config/sync/core.base_field_override.node.article.promote.yml
@@ -1,0 +1,22 @@
+uuid: fbc45748-dd1c-4af1-b06f-5173abbd6277
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.article
+id: node.article.promote
+field_name: promote
+entity_type: node
+bundle: article
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/core.base_field_override.node.article.status.yml
+++ b/config/sync/core.base_field_override.node.article.status.yml
@@ -1,0 +1,22 @@
+uuid: 4f987927-f154-46de-bf7f-a453c3e40209
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.article
+id: node.article.status
+field_name: status
+entity_type: node
+bundle: article
+label: Published
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/core.base_field_override.node.article.sticky.yml
+++ b/config/sync/core.base_field_override.node.article.sticky.yml
@@ -1,0 +1,22 @@
+uuid: 5d931273-7916-45ec-8ded-68cda0f5f098
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.article
+id: node.article.sticky
+field_name: sticky
+entity_type: node
+bundle: article
+label: 'Sticky at top of lists'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/core.base_field_override.node.article.title.yml
+++ b/config/sync/core.base_field_override.node.article.title.yml
@@ -1,0 +1,18 @@
+uuid: 9f96a38c-1e2b-456e-bd0b-3d61cd8fbfd4
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.article
+id: node.article.title
+field_name: title
+entity_type: node
+bundle: article
+label: Title
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/core.base_field_override.node.article.uid.yml
+++ b/config/sync/core.base_field_override.node.article.uid.yml
@@ -1,0 +1,20 @@
+uuid: dca36e1d-74b5-440b-98d6-d22a2375c42e
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.article
+id: node.article.uid
+field_name: uid
+entity_type: node
+bundle: article
+label: 'Authored by'
+description: 'The username of the content author.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\node\Entity\Node::getDefaultEntityOwner'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/sync/core.base_field_override.node.page.changed.yml
+++ b/config/sync/core.base_field_override.node.page.changed.yml
@@ -1,0 +1,18 @@
+uuid: f9450c7f-0c4a-4805-b76d-0b5bcb6892ac
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.page
+id: node.page.changed
+field_name: changed
+entity_type: node
+bundle: page
+label: Changed
+description: 'The time that the node was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/sync/core.base_field_override.node.page.created.yml
+++ b/config/sync/core.base_field_override.node.page.created.yml
@@ -1,0 +1,18 @@
+uuid: a7b8340d-924c-4d2d-8ba3-4c6995a13c57
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.page
+id: node.page.created
+field_name: created
+entity_type: node
+bundle: page
+label: 'Authored on'
+description: 'The date and time that the content was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/config/sync/core.base_field_override.node.page.path.yml
+++ b/config/sync/core.base_field_override.node.page.path.yml
@@ -1,0 +1,20 @@
+uuid: 1d643c4a-1e9c-48ad-8cd3-fc7ef9db2160
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.page
+  module:
+    - path
+id: node.page.path
+field_name: path
+entity_type: node
+bundle: page
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/config/sync/core.base_field_override.node.page.status.yml
+++ b/config/sync/core.base_field_override.node.page.status.yml
@@ -1,0 +1,22 @@
+uuid: 03aee5c2-5457-4687-8d07-6ec7ad462e4e
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.page
+id: node.page.status
+field_name: status
+entity_type: node
+bundle: page
+label: Published
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/core.base_field_override.node.page.sticky.yml
+++ b/config/sync/core.base_field_override.node.page.sticky.yml
@@ -1,0 +1,22 @@
+uuid: 60eab8c1-6cd2-4080-8301-9a84a0bc37af
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.page
+id: node.page.sticky
+field_name: sticky
+entity_type: node
+bundle: page
+label: 'Sticky at top of lists'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/core.base_field_override.node.page.title.yml
+++ b/config/sync/core.base_field_override.node.page.title.yml
@@ -1,0 +1,18 @@
+uuid: 1259bcf1-a47d-4159-a0d7-3172eb5ba201
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.page
+id: node.page.title
+field_name: title
+entity_type: node
+bundle: page
+label: Title
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/core.base_field_override.node.page.uid.yml
+++ b/config/sync/core.base_field_override.node.page.uid.yml
@@ -1,0 +1,20 @@
+uuid: a3911d95-4643-4c85-9b26-c35f8d486fe1
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.page
+id: node.page.uid
+field_name: uid
+entity_type: node
+bundle: page
+label: 'Authored by'
+description: 'The username of the content author.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\node\Entity\Node::getDefaultEntityOwner'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/sync/core.base_field_override.shortcut.default.title.yml
+++ b/config/sync/core.base_field_override.shortcut.default.title.yml
@@ -1,0 +1,18 @@
+uuid: 8a7a9cd4-9fc0-48fd-85e5-0d58ee64b64a
+langcode: en
+status: true
+dependencies:
+  config:
+    - shortcut.set.default
+id: shortcut.default.title
+field_name: title
+entity_type: shortcut
+bundle: default
+label: Name
+description: 'The name of the shortcut.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/core.base_field_override.user.user.changed.yml
+++ b/config/sync/core.base_field_override.user.user.changed.yml
@@ -1,0 +1,18 @@
+uuid: 6cf2bb53-4a56-4d9b-90e3-ba5017ba040e
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+id: user.user.changed
+field_name: changed
+entity_type: user
+bundle: user
+label: Changed
+description: 'The time that the user was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/sync/field.field.block_content.basic.body.yml
+++ b/config/sync/field.field.block_content.basic.body.yml
@@ -16,7 +16,7 @@ bundle: basic
 label: Body
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/sync/field.field.comment.comment.comment_body.yml
+++ b/config/sync/field.field.comment.comment.comment_body.yml
@@ -16,7 +16,7 @@ bundle: comment
 label: Comment
 description: ''
 required: true
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/sync/field.field.node.article.body.yml
+++ b/config/sync/field.field.node.article.body.yml
@@ -16,7 +16,7 @@ bundle: article
 label: Body
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/sync/field.field.node.article.comment.yml
+++ b/config/sync/field.field.node.article.comment.yml
@@ -16,7 +16,7 @@ bundle: article
 label: Comments
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value:
   -
     status: 2

--- a/config/sync/field.field.node.article.field_image.yml
+++ b/config/sync/field.field.node.article.field_image.yml
@@ -16,7 +16,7 @@ bundle: article
 label: Image
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/sync/field.field.node.article.field_tags.yml
+++ b/config/sync/field.field.node.article.field_tags.yml
@@ -15,7 +15,7 @@ bundle: article
 label: Tags
 description: 'Enter a comma-separated list. For example: Amsterdam, Mexico City, "Cleveland, Ohio"'
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/sync/field.field.node.page.body.yml
+++ b/config/sync/field.field.node.page.body.yml
@@ -16,7 +16,7 @@ bundle: page
 label: Body
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/sync/field.field.user.user.user_picture.yml
+++ b/config/sync/field.field.user.user.user_picture.yml
@@ -16,7 +16,7 @@ bundle: user
 label: Picture
 description: 'Your virtual face or picture.'
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/sync/language.content_settings.block_content.basic.yml
+++ b/config/sync/language.content_settings.block_content.basic.yml
@@ -1,0 +1,18 @@
+uuid: 070425f7-a41d-44ac-8119-62d73c6d3c2f
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.basic
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: block_content.basic
+target_entity_type_id: block_content
+target_bundle: basic
+default_langcode: site_default
+language_alterable: false

--- a/config/sync/language.content_settings.comment.comment.yml
+++ b/config/sync/language.content_settings.comment.comment.yml
@@ -1,0 +1,18 @@
+uuid: c6c3cad8-31ad-49f2-93ea-2937807394c5
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.comment
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: comment.comment
+target_entity_type_id: comment
+target_bundle: comment
+default_langcode: site_default
+language_alterable: false

--- a/config/sync/language.content_settings.contact_message.feedback.yml
+++ b/config/sync/language.content_settings.contact_message.feedback.yml
@@ -1,0 +1,11 @@
+uuid: b297ad92-912c-4eb2-8445-49201ed46722
+langcode: en
+status: true
+dependencies:
+  config:
+    - contact.form.feedback
+id: contact_message.feedback
+target_entity_type_id: contact_message
+target_bundle: feedback
+default_langcode: site_default
+language_alterable: false

--- a/config/sync/language.content_settings.contact_message.personal.yml
+++ b/config/sync/language.content_settings.contact_message.personal.yml
@@ -1,0 +1,11 @@
+uuid: 036410f6-4b62-41a1-9c37-8536e7929807
+langcode: en
+status: true
+dependencies:
+  config:
+    - contact.form.personal
+id: contact_message.personal
+target_entity_type_id: contact_message
+target_bundle: personal
+default_langcode: site_default
+language_alterable: false

--- a/config/sync/language.content_settings.file.file.yml
+++ b/config/sync/language.content_settings.file.file.yml
@@ -1,0 +1,11 @@
+uuid: d7a8b655-1ed0-4de9-b701-459a16cddfb1
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+id: file.file
+target_entity_type_id: file
+target_bundle: file
+default_langcode: site_default
+language_alterable: false

--- a/config/sync/language.content_settings.menu_link_content.menu_link_content.yml
+++ b/config/sync/language.content_settings.menu_link_content.menu_link_content.yml
@@ -1,0 +1,17 @@
+uuid: cbcd2f0c-4fe7-43bb-a637-a33e911a8771
+langcode: en
+status: true
+dependencies:
+  module:
+    - content_translation
+    - menu_link_content
+third_party_settings:
+  content_translation:
+    enabled: false
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: menu_link_content.menu_link_content
+target_entity_type_id: menu_link_content
+target_bundle: menu_link_content
+default_langcode: site_default
+language_alterable: false

--- a/config/sync/language.content_settings.node.article.yml
+++ b/config/sync/language.content_settings.node.article.yml
@@ -1,0 +1,18 @@
+uuid: f264e1cb-0e53-45c3-9864-b6d6bf884fd7
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.article
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: node.article
+target_entity_type_id: node
+target_bundle: article
+default_langcode: site_default
+language_alterable: false

--- a/config/sync/language.content_settings.node.page.yml
+++ b/config/sync/language.content_settings.node.page.yml
@@ -1,0 +1,18 @@
+uuid: a4ef495f-e831-4225-b322-496ebe0b55b8
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.page
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: node.page
+target_entity_type_id: node
+target_bundle: page
+default_langcode: site_default
+language_alterable: false

--- a/config/sync/language.content_settings.shortcut.default.yml
+++ b/config/sync/language.content_settings.shortcut.default.yml
@@ -1,0 +1,18 @@
+uuid: 0270e929-25d6-4662-a61b-cb5ad728a55b
+langcode: en
+status: true
+dependencies:
+  config:
+    - shortcut.set.default
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: shortcut.default
+target_entity_type_id: shortcut
+target_bundle: default
+default_langcode: site_default
+language_alterable: false

--- a/config/sync/language.content_settings.taxonomy_term.categories.yml
+++ b/config/sync/language.content_settings.taxonomy_term.categories.yml
@@ -1,0 +1,16 @@
+uuid: 466b9307-207b-494f-a0d4-a5fba6cdbd54
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.categories
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: taxonomy_term.categories
+target_entity_type_id: taxonomy_term
+target_bundle: categories
+default_langcode: nl
+language_alterable: true

--- a/config/sync/language.content_settings.taxonomy_term.provincies.yml
+++ b/config/sync/language.content_settings.taxonomy_term.provincies.yml
@@ -1,0 +1,16 @@
+uuid: c530cebb-6c0d-4d59-b8c0-1239b5972e54
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.provincies
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: taxonomy_term.provincies
+target_entity_type_id: taxonomy_term
+target_bundle: provincies
+default_langcode: nl
+language_alterable: true

--- a/config/sync/language.content_settings.taxonomy_term.tags.yml
+++ b/config/sync/language.content_settings.taxonomy_term.tags.yml
@@ -1,0 +1,18 @@
+uuid: 8da35b87-43f7-4627-8f67-d4f37e5effa0
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.tags
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: taxonomy_term.tags
+target_entity_type_id: taxonomy_term
+target_bundle: tags
+default_langcode: nl
+language_alterable: true

--- a/config/sync/language.content_settings.user.user.yml
+++ b/config/sync/language.content_settings.user.user.yml
@@ -1,0 +1,17 @@
+uuid: 81de0964-54fe-4509-bf38-fe487d6abaec
+langcode: en
+status: true
+dependencies:
+  module:
+    - content_translation
+    - user
+third_party_settings:
+  content_translation:
+    enabled: false
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: user.user
+target_entity_type_id: user
+target_bundle: user
+default_langcode: site_default
+language_alterable: false

--- a/config/sync/language/fr/webform.settings.yml
+++ b/config/sync/language/fr/webform.settings.yml
@@ -1,10 +1,10 @@
 settings:
-  default_form_open_message: "Ce formulaire n'est actuellement pas ouvert aux soumissions."
-  default_form_close_message: 'Désolé... Ce formulaire est clos aux nouvelles soumissions.'
-  default_form_exception_message: "Il est impossible d'afficher ce webform. Veuillez contacter l'administrateur du site."
   default_submit_button_label: Soumettre
   default_reset_button_label: Réinitialiser
   default_delete_button_label: Supprimer
+  default_form_open_message: "Ce formulaire n'est actuellement pas ouvert aux soumissions."
+  default_form_close_message: 'Désolé... Ce formulaire est clos aux nouvelles soumissions.'
+  default_form_exception_message: "Il est impossible d'afficher ce webform. Veuillez contacter l'administrateur du site."
   default_form_confidential_message: 'Ce formulaire est confidentiel. Vous devez vous <a href="[site:login-url]/logout?destination=[current-page:url:relative]">déconnecter</a> pour l''utiliser.'
   default_form_required_label: 'Indique si le champs est requis'
   default_wizard_prev_button_label: '< Précédent'
@@ -24,11 +24,11 @@ settings:
   default_draft_pending_multiple_message: 'Vous avez des brouillons en attente pour ce webform. <a href="#">Voir les brouillons en attente</a>.'
   default_confirmation_message: 'Nouvelle soumission ajoutée à [webform:title]'
   default_confirmation_back_label: 'Retour au formulaire'
+  default_limit_total_message: 'Vous avez dépassé la limite de soumission du formulaire.'
+  default_limit_user_message: 'Vous avez dépassé la limite de soumission du formulaire.'
   default_submission_label: '[webform_submission:submitted-to]: Soumission #[webform_submission:serial]'
   default_submission_locked_message: 'Cette soumission a été verrouillée.'
   default_autofill_message: 'Cette soumission a été pré-remplie grâce à votre précédente soumission.'
-  default_limit_total_message: 'Vous avez dépassé la limite de soumission du formulaire.'
-  default_limit_user_message: 'Vous avez dépassé la limite de soumission du formulaire.'
   dialog_options:
     narrow:
       title: Étroit

--- a/config/sync/language/nl/webform.settings.yml
+++ b/config/sync/language/nl/webform.settings.yml
@@ -1,10 +1,10 @@
 settings:
-  default_form_open_message: 'Dit formulier is nog niet geopend voor inzendingen.'
-  default_form_close_message: 'Sorry... Dit formulier is gesloten voor nieuwe inzendingen.'
-  default_form_exception_message: 'Het formulier kan niet getoond worden. Neem contact op met de beheerder.'
   default_submit_button_label: Indienen
   default_reset_button_label: 'Opnieuw instellen'
   default_delete_button_label: Verwijderen
+  default_form_open_message: 'Dit formulier is nog niet geopend voor inzendingen.'
+  default_form_close_message: 'Sorry... Dit formulier is gesloten voor nieuwe inzendingen.'
+  default_form_exception_message: 'Het formulier kan niet getoond worden. Neem contact op met de beheerder.'
   default_form_confidential_message: 'Dit formulier is vertrouwelijk en kan pas na <a href="[site:login-url]/logout?destination=[current-page:url:relative]">uitloggen</a> worden gebruikt.'
   default_form_access_denied_message: 'Log in om toegang te krijgen tot dit formulier.'
   default_form_required_label: 'Aanduiding van verplicht veld'
@@ -26,6 +26,8 @@ settings:
   default_draft_pending_multiple_message: 'U heeft openstaande concepten voor dit formulier. <a href="#">Bekijk uw openstaande concepten</a>.'
   default_confirmation_message: 'Nieuwe inzending voor [webform:title] opgeslagen.'
   default_confirmation_back_label: 'Terug naar formulier'
+  default_limit_total_message: 'Geen nieuwe inzendingen toegestaan.'
+  default_limit_user_message: 'Geen nieuwe inzendingen toegestaan.'
   default_submission_label: '[webform_submission:submitted-to]: Inzending #[webform_submission:serial]'
   default_submission_access_denied_message: 'Log in om toegang te krijgen tot de inzending.'
   default_submission_exception_message: 'De inzending kan niet verwerkt worden. Neem alstublieft contact op met de site administrator.'
@@ -33,8 +35,6 @@ settings:
   default_previous_submission_message: 'U heeft dit formulier reeds ingezonden. <a href="#">Bekijk uw vorige inzending</a>.'
   default_previous_submissions_message: 'U heeft dit formulier reeds ingezonden. <a href="#">Bekijk uw vorige inzendingen</a>.'
   default_autofill_message: 'Deze inzending is automatisch ingevuld met uw vorige inzending.'
-  default_limit_total_message: 'Geen nieuwe inzendingen toegestaan.'
-  default_limit_user_message: 'Geen nieuwe inzendingen toegestaan.'
   dialog_options:
     narrow:
       title: Smal

--- a/config/sync/taxonomy.vocabulary.categories.yml
+++ b/config/sync/taxonomy.vocabulary.categories.yml
@@ -1,0 +1,9 @@
+uuid: 32d85452-cbe5-4c91-912d-4cc78eab0703
+langcode: nl
+status: true
+dependencies: {  }
+name: Categories
+vid: categories
+description: 'location categories'
+weight: 0
+new_revision: false

--- a/config/sync/taxonomy.vocabulary.provincies.yml
+++ b/config/sync/taxonomy.vocabulary.provincies.yml
@@ -1,0 +1,9 @@
+uuid: 03193728-ebc6-4771-91b6-448630e26653
+langcode: nl
+status: true
+dependencies: {  }
+name: Provincies
+vid: provincies
+description: null
+weight: 0
+new_revision: false

--- a/config/sync/views.view.webform_submissions.yml
+++ b/config/sync/views.view.webform_submissions.yml
@@ -19,156 +19,12 @@ base_table: webform_submission
 base_field: sid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: none
-        options: {  }
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: full
-        options:
-          items_per_page: 25
-          offset: 0
-          id: 0
-          total_pages: null
-          tags:
-            previous: ‹‹
-            next: ››
-            first: '« First'
-            last: 'Last »'
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50, 100, 200'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          quantity: 9
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
-          columns:
-            webform_submission_bulk_form: webform_submission_bulk_form
-            sid: sid
-            in_draft: in_draft
-            sticky: sticky
-            locked: locked
-            created: created
-            completed: completed
-            remote_addr: remote_addr
-            view_webform_submission: view_webform_submission
-            edit_webform_submission: view_webform_submission
-          info:
-            webform_submission_bulk_form:
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            sid:
-              sortable: true
-              default_sort_order: desc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            in_draft:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            sticky:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            locked:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            created:
-              sortable: true
-              default_sort_order: desc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            completed:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            remote_addr:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            view_webform_submission:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ' '
-              empty_column: false
-              responsive: ''
-            edit_webform_submission:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          default: created
-          empty_table: false
-      row:
-        type: fields
-        options:
-          inline: {  }
-          separator: ''
-          hide_empty: false
-          default_field_elements: true
+      title: 'Webform submissions'
       fields:
         sid:
           id: sid
@@ -177,6 +33,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: sid
+          plugin_id: field
           label: '#'
           exclude: false
           alter:
@@ -233,9 +92,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: sid
-          plugin_id: field
         in_draft:
           id: in_draft
           table: webform_submission
@@ -243,6 +99,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: in_draft
+          plugin_id: field
           label: Draft
           exclude: false
           alter:
@@ -288,8 +147,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -300,9 +159,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: in_draft
-          plugin_id: field
         created:
           id: created
           table: webform_submission
@@ -310,6 +166,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: created
+          plugin_id: field
           label: Created
           exclude: false
           alter:
@@ -367,9 +226,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: created
-          plugin_id: field
         remote_addr:
           id: remote_addr
           table: webform_submission
@@ -377,6 +233,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: remote_addr
+          plugin_id: field
           label: 'IP address'
           exclude: false
           alter:
@@ -432,9 +291,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: remote_addr
-          plugin_id: field
         view_webform_submission:
           id: view_webform_submission
           table: webform_submission
@@ -442,6 +298,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          plugin_id: entity_link
           label: Operations
           exclude: false
           alter:
@@ -486,22 +344,43 @@ display:
           text: view
           output_url_as_text: false
           absolute: false
-          entity_type: webform_submission
-          plugin_id: entity_link
-      filters: {  }
-      sorts: {  }
-      header:
-        result:
-          id: result
-          table: views
-          field: result
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          content: 'Displaying @start - @end of @total'
-          plugin_id: result
-      footer: {  }
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 25
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50, 100, 200'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: none
+        options: {  }
+      cache:
+        type: tag
+        options: {  }
       empty:
         area_text_custom:
           id: area_text_custom
@@ -510,11 +389,11 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          empty: true
-          tokenize: false
-          content: 'No submissions available.'
           plugin_id: text_custom
-      relationships: {  }
+          empty: true
+          content: 'No submissions available.'
+          tokenize: false
+      sorts: {  }
       arguments:
         webform_id:
           id: webform_id
@@ -551,6 +430,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: in_draft
+          plugin_id: numeric
           default_action: ignore
           exception:
             value: all
@@ -564,8 +446,8 @@ display:
           summary_options:
             base_path: ''
             count: true
-            items_per_page: 25
             override: false
+            items_per_page: 25
           summary:
             sort_order: asc
             number_of_records: 0
@@ -577,42 +459,16 @@ display:
           validate_options: {  }
           break_phrase: false
           not: false
-          entity_type: webform_submission
-          entity_field: in_draft
-          plugin_id: numeric
-      display_extenders: {  }
+      filters: {  }
       filter_groups:
         operator: AND
         groups: {  }
-      title: 'Webform submissions'
-    cache_metadata:
-      max-age: -1
-      contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
-        - url
-        - url.query_args
-        - user
-      tags: {  }
-  embed_administer:
-    display_plugin: embed
-    id: embed_administer
-    display_title: 'Embed: Administer'
-    position: 2
-    display_options:
-      display_extenders: {  }
-      display_description: 'Administer submissions.'
       style:
         type: table
         options:
           grouping: {  }
           row_class: ''
           default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
           columns:
             webform_submission_bulk_form: webform_submission_bulk_form
             sid: sid
@@ -624,6 +480,7 @@ display:
             remote_addr: remote_addr
             view_webform_submission: view_webform_submission
             edit_webform_submission: view_webform_submission
+          default: created
           info:
             webform_submission_bulk_form:
               align: ''
@@ -693,26 +550,56 @@ display:
               separator: ''
               empty_column: false
               responsive: ''
-          default: created
+          override: true
+          sticky: false
+          summary: ''
           empty_table: false
-      defaults:
-        style: false
-        row: false
-        access: false
-        fields: false
-        filters: false
-        filter_groups: false
+          caption: ''
+          description: ''
       row:
         type: fields
         options:
+          default_field_elements: true
           inline: {  }
           separator: ''
           hide_empty: false
-          default_field_elements: true
-      access:
-        type: perm
+      query:
+        type: views_query
         options:
-          perm: 'administer webform submission'
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: result
+          empty: false
+          content: 'Displaying @start - @end of @total'
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+      tags: {  }
+  embed_administer:
+    id: embed_administer
+    display_title: 'Embed: Administer'
+    display_plugin: embed
+    position: 2
+    display_options:
       fields:
         webform_submission_bulk_form:
           id: webform_submission_bulk_form
@@ -721,6 +608,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          plugin_id: webform_submission_bulk_form
           label: 'Webform submission operations bulk form'
           exclude: false
           alter:
@@ -765,8 +654,6 @@ display:
           action_title: Action
           include_exclude: exclude
           selected_actions: {  }
-          entity_type: webform_submission
-          plugin_id: webform_submission_bulk_form
         sid:
           id: sid
           table: webform_submission
@@ -774,6 +661,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: sid
+          plugin_id: field
           label: '#'
           exclude: false
           alter:
@@ -830,9 +720,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: sid
-          plugin_id: field
         in_draft:
           id: in_draft
           table: webform_submission
@@ -840,6 +727,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: in_draft
+          plugin_id: field
           label: Draft
           exclude: false
           alter:
@@ -885,8 +775,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -897,9 +787,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: in_draft
-          plugin_id: field
         sticky:
           id: sticky
           table: webform_submission
@@ -907,6 +794,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: sticky
+          plugin_id: field
           label: Sticky
           exclude: false
           alter:
@@ -952,8 +842,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -964,9 +854,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: sticky
-          plugin_id: field
         locked:
           id: locked
           table: webform_submission
@@ -974,6 +861,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: locked
+          plugin_id: field
           label: Locked
           exclude: false
           alter:
@@ -1019,8 +909,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -1031,9 +921,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: locked
-          plugin_id: field
         created:
           id: created
           table: webform_submission
@@ -1041,6 +928,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: created
+          plugin_id: field
           label: Created
           exclude: false
           alter:
@@ -1098,9 +988,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: created
-          plugin_id: field
         completed:
           id: completed
           table: webform_submission
@@ -1108,6 +995,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: completed
+          plugin_id: field
           label: Completed
           exclude: false
           alter:
@@ -1165,9 +1055,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: completed
-          plugin_id: field
         remote_addr:
           id: remote_addr
           table: webform_submission
@@ -1175,6 +1062,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: remote_addr
+          plugin_id: field
           label: 'IP address'
           exclude: false
           alter:
@@ -1230,9 +1120,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: remote_addr
-          plugin_id: field
         operations:
           id: operations
           table: webform_submission
@@ -1240,6 +1127,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: entity_operations
           label: Operations
           exclude: false
           alter:
@@ -1282,9 +1172,10 @@ display:
           empty_zero: false
           hide_alter_empty: true
           destination: true
-          entity_type: null
-          entity_field: null
-          plugin_id: entity_operations
+      access:
+        type: perm
+        options:
+          perm: 'administer webform submission'
       filters:
         in_draft:
           id: in_draft
@@ -1293,6 +1184,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: in_draft
+          plugin_id: boolean
           operator: '='
           value: All
           group: 1
@@ -1303,6 +1197,8 @@ display:
             description: ''
             use_operator: false
             operator: in_draft_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: in_draft
             required: false
             remember: false
@@ -1311,8 +1207,6 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1325,9 +1219,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: webform_submission
-          entity_field: in_draft
-          plugin_id: boolean
         sticky:
           id: sticky
           table: webform_submission
@@ -1335,6 +1226,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: sticky
+          plugin_id: boolean
           operator: '='
           value: All
           group: 1
@@ -1345,6 +1239,8 @@ display:
             description: ''
             use_operator: false
             operator: sticky_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: sticky
             required: false
             remember: false
@@ -1353,8 +1249,6 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1367,9 +1261,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: webform_submission
-          entity_field: sticky
-          plugin_id: boolean
         locked:
           id: locked
           table: webform_submission
@@ -1377,6 +1268,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: locked
+          plugin_id: boolean
           operator: '='
           value: All
           group: 1
@@ -1387,6 +1281,8 @@ display:
             description: ''
             use_operator: false
             operator: locked_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: locked
             required: false
             remember: false
@@ -1396,8 +1292,6 @@ display:
               anonymous: '0'
               administrator: '0'
               demo_region: '0'
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1410,13 +1304,119 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: webform_submission
-          entity_field: locked
-          plugin_id: boolean
       filter_groups:
         operator: AND
         groups:
           1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            webform_submission_bulk_form: webform_submission_bulk_form
+            sid: sid
+            in_draft: in_draft
+            sticky: sticky
+            locked: locked
+            created: created
+            completed: completed
+            remote_addr: remote_addr
+            view_webform_submission: view_webform_submission
+            edit_webform_submission: view_webform_submission
+          default: created
+          info:
+            webform_submission_bulk_form:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            sid:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            in_draft:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            sticky:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            locked:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            created:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            completed:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            remote_addr:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            view_webform_submission:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ' '
+              empty_column: false
+              responsive: ''
+            edit_webform_submission:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      defaults:
+        access: false
+        style: false
+        row: false
+        fields: false
+        filters: false
+        filter_groups: false
+      display_description: 'Administer submissions.'
+      display_extenders: {  }
     cache_metadata:
       max-age: 0
       contexts:
@@ -1428,36 +1428,24 @@ display:
         - user.permissions
       tags: {  }
   embed_default:
-    display_plugin: embed
     id: embed_default
     display_title: 'Embed: Default'
+    display_plugin: embed
     position: 1
     display_options:
-      display_extenders: {  }
-      display_description: 'Display submissions.'
-      defaults:
-        fields: true
-        style: false
-        row: false
-        filters: true
-        filter_groups: true
       style:
         type: table
         options:
           grouping: {  }
           row_class: ''
           default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
           columns:
             sid: sid
             in_draft: in_draft
             created: created
             remote_addr: remote_addr
             view_webform_submission: view_webform_submission
+          default: created
           info:
             sid:
               sortable: true
@@ -1494,15 +1482,27 @@ display:
               separator: ' '
               empty_column: false
               responsive: ''
-          default: created
+          override: true
+          sticky: false
+          summary: ''
           empty_table: false
+          caption: ''
+          description: ''
       row:
         type: fields
         options:
+          default_field_elements: true
           inline: {  }
           separator: ''
           hide_empty: false
-          default_field_elements: true
+      defaults:
+        style: false
+        row: false
+        fields: true
+        filters: true
+        filter_groups: true
+      display_description: 'Display submissions.'
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -1513,13 +1513,11 @@ display:
         - user
       tags: {  }
   embed_manage:
-    display_plugin: embed
     id: embed_manage
     display_title: 'Embed: Manage'
+    display_plugin: embed
     position: 3
     display_options:
-      display_extenders: {  }
-      display_description: 'Manage submissions.'
       fields:
         webform_submission_bulk_form:
           id: webform_submission_bulk_form
@@ -1528,6 +1526,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          plugin_id: webform_submission_bulk_form
           label: 'Webform submission operations bulk form'
           exclude: false
           alter:
@@ -1576,8 +1576,6 @@ display:
             - webform_submission_make_sticky_action
             - webform_submission_make_unlock_action
             - webform_submission_make_unsticky_action
-          entity_type: webform_submission
-          plugin_id: webform_submission_bulk_form
         sid:
           id: sid
           table: webform_submission
@@ -1585,6 +1583,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: sid
+          plugin_id: field
           label: '#'
           exclude: false
           alter:
@@ -1641,9 +1642,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: sid
-          plugin_id: field
         in_draft:
           id: in_draft
           table: webform_submission
@@ -1651,6 +1649,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: in_draft
+          plugin_id: field
           label: Draft
           exclude: false
           alter:
@@ -1696,8 +1697,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -1708,9 +1709,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: in_draft
-          plugin_id: field
         sticky:
           id: sticky
           table: webform_submission
@@ -1718,6 +1716,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: sticky
+          plugin_id: field
           label: Sticky
           exclude: false
           alter:
@@ -1763,8 +1764,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -1775,9 +1776,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: sticky
-          plugin_id: field
         locked:
           id: locked
           table: webform_submission
@@ -1785,6 +1783,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: locked
+          plugin_id: field
           label: Locked
           exclude: false
           alter:
@@ -1830,8 +1831,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -1842,9 +1843,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: locked
-          plugin_id: field
         created:
           id: created
           table: webform_submission
@@ -1852,6 +1850,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: created
+          plugin_id: field
           label: Created
           exclude: false
           alter:
@@ -1909,9 +1910,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: created
-          plugin_id: field
         completed:
           id: completed
           table: webform_submission
@@ -1919,6 +1917,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: completed
+          plugin_id: field
           label: Completed
           exclude: false
           alter:
@@ -1976,9 +1977,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: completed
-          plugin_id: field
         remote_addr:
           id: remote_addr
           table: webform_submission
@@ -1986,6 +1984,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: remote_addr
+          plugin_id: field
           label: 'IP address'
           exclude: false
           alter:
@@ -2041,9 +2042,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: remote_addr
-          plugin_id: field
         view_webform_submission:
           id: view_webform_submission
           table: webform_submission
@@ -2051,6 +2049,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          plugin_id: entity_link
           label: Operations
           exclude: false
           alter:
@@ -2095,8 +2095,6 @@ display:
           text: view
           output_url_as_text: false
           absolute: false
-          entity_type: webform_submission
-          plugin_id: entity_link
         edit_webform_submission:
           id: edit_webform_submission
           table: webform_submission
@@ -2104,6 +2102,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          plugin_id: entity_link_edit
           label: Operations
           exclude: false
           alter:
@@ -2148,26 +2148,148 @@ display:
           text: edit
           output_url_as_text: false
           absolute: false
+      access:
+        type: perm
+        options:
+          perm: 'edit any webform submission'
+      filters:
+        in_draft:
+          id: in_draft
+          table: webform_submission
+          field: in_draft
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: webform_submission
-          plugin_id: entity_link_edit
-      defaults:
-        fields: false
-        style: false
-        row: false
-        access: false
-        filters: false
-        filter_groups: false
+          entity_field: in_draft
+          plugin_id: boolean
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: 'Is draft'
+            description: ''
+            use_operator: false
+            operator: in_draft_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: in_draft
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        sticky:
+          id: sticky
+          table: webform_submission
+          field: sticky
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: webform_submission
+          entity_field: sticky
+          plugin_id: boolean
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Sticky
+            description: ''
+            use_operator: false
+            operator: sticky_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: sticky
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        locked:
+          id: locked
+          table: webform_submission
+          field: locked
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: webform_submission
+          entity_field: locked
+          plugin_id: boolean
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Locked
+            description: ''
+            use_operator: false
+            operator: locked_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: locked
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              demo_region: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       style:
         type: table
         options:
           grouping: {  }
           row_class: ''
           default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
           columns:
             webform_submission_bulk_form: webform_submission_bulk_form
             sid: sid
@@ -2179,6 +2301,7 @@ display:
             remote_addr: remote_addr
             view_webform_submission: view_webform_submission
             edit_webform_submission: view_webform_submission
+          default: created
           info:
             webform_submission_bulk_form:
               align: ''
@@ -2248,151 +2371,28 @@ display:
               separator: ''
               empty_column: false
               responsive: ''
-          default: created
+          override: true
+          sticky: false
+          summary: ''
           empty_table: false
+          caption: ''
+          description: ''
       row:
         type: fields
         options:
+          default_field_elements: true
           inline: {  }
           separator: ''
           hide_empty: false
-          default_field_elements: true
-      access:
-        type: perm
-        options:
-          perm: 'edit any webform submission'
-      filters:
-        in_draft:
-          id: in_draft
-          table: webform_submission
-          field: in_draft
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: All
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: 'Is draft'
-            description: ''
-            use_operator: false
-            operator: in_draft_op
-            identifier: in_draft
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: webform_submission
-          entity_field: in_draft
-          plugin_id: boolean
-        sticky:
-          id: sticky
-          table: webform_submission
-          field: sticky
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: All
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: Sticky
-            description: ''
-            use_operator: false
-            operator: sticky_op
-            identifier: sticky
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: webform_submission
-          entity_field: sticky
-          plugin_id: boolean
-        locked:
-          id: locked
-          table: webform_submission
-          field: locked
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: All
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: Locked
-            description: ''
-            use_operator: false
-            operator: locked_op
-            identifier: locked
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              demo_region: '0'
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: webform_submission
-          entity_field: locked
-          plugin_id: boolean
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
+      defaults:
+        access: false
+        style: false
+        row: false
+        fields: false
+        filters: false
+        filter_groups: false
+      display_description: 'Manage submissions.'
+      display_extenders: {  }
     cache_metadata:
       max-age: 0
       contexts:
@@ -2404,13 +2404,11 @@ display:
         - user.permissions
       tags: {  }
   embed_review:
-    display_plugin: embed
     id: embed_review
     display_title: 'Embed: Review'
+    display_plugin: embed
     position: 4
     display_options:
-      display_extenders: {  }
-      display_description: 'Review submissions.'
       fields:
         sid:
           id: sid
@@ -2419,6 +2417,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: sid
+          plugin_id: field
           label: '#'
           exclude: false
           alter:
@@ -2475,9 +2476,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: sid
-          plugin_id: field
         in_draft:
           id: in_draft
           table: webform_submission
@@ -2485,6 +2483,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: in_draft
+          plugin_id: field
           label: Draft
           exclude: false
           alter:
@@ -2530,8 +2531,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -2542,9 +2543,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: in_draft
-          plugin_id: field
         sticky:
           id: sticky
           table: webform_submission
@@ -2552,6 +2550,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: sticky
+          plugin_id: field
           label: Sticky
           exclude: false
           alter:
@@ -2597,8 +2598,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -2609,9 +2610,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: sticky
-          plugin_id: field
         locked:
           id: locked
           table: webform_submission
@@ -2619,6 +2617,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: locked
+          plugin_id: field
           label: Locked
           exclude: false
           alter:
@@ -2664,8 +2665,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -2676,9 +2677,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: locked
-          plugin_id: field
         created:
           id: created
           table: webform_submission
@@ -2686,6 +2684,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: created
+          plugin_id: field
           label: Created
           exclude: false
           alter:
@@ -2743,9 +2744,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: created
-          plugin_id: field
         completed:
           id: completed
           table: webform_submission
@@ -2753,6 +2751,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: completed
+          plugin_id: field
           label: Completed
           exclude: false
           alter:
@@ -2810,9 +2811,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: completed
-          plugin_id: field
         remote_addr:
           id: remote_addr
           table: webform_submission
@@ -2820,6 +2818,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: remote_addr
+          plugin_id: field
           label: 'IP address'
           exclude: false
           alter:
@@ -2875,9 +2876,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: remote_addr
-          plugin_id: field
         view_webform_submission:
           id: view_webform_submission
           table: webform_submission
@@ -2885,6 +2883,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          plugin_id: entity_link
           label: Operations
           exclude: false
           alter:
@@ -2929,26 +2929,148 @@ display:
           text: view
           output_url_as_text: false
           absolute: false
+      access:
+        type: perm
+        options:
+          perm: 'view any webform submission'
+      filters:
+        in_draft:
+          id: in_draft
+          table: webform_submission
+          field: in_draft
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: webform_submission
-          plugin_id: entity_link
-      defaults:
-        fields: false
-        style: false
-        row: false
-        access: false
-        filters: false
-        filter_groups: false
+          entity_field: in_draft
+          plugin_id: boolean
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: 'Is draft'
+            description: ''
+            use_operator: false
+            operator: in_draft_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: in_draft
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        sticky:
+          id: sticky
+          table: webform_submission
+          field: sticky
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: webform_submission
+          entity_field: sticky
+          plugin_id: boolean
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Sticky
+            description: ''
+            use_operator: false
+            operator: sticky_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: sticky
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        locked:
+          id: locked
+          table: webform_submission
+          field: locked
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: webform_submission
+          entity_field: locked
+          plugin_id: boolean
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Locked
+            description: ''
+            use_operator: false
+            operator: locked_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: locked
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              demo_region: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       style:
         type: table
         options:
           grouping: {  }
           row_class: ''
           default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
           columns:
             webform_submission_bulk_form: webform_submission_bulk_form
             sid: sid
@@ -2960,6 +3082,7 @@ display:
             remote_addr: remote_addr
             view_webform_submission: view_webform_submission
             edit_webform_submission: view_webform_submission
+          default: created
           info:
             webform_submission_bulk_form:
               align: ''
@@ -3029,151 +3152,28 @@ display:
               separator: ''
               empty_column: false
               responsive: ''
-          default: created
+          override: true
+          sticky: false
+          summary: ''
           empty_table: false
+          caption: ''
+          description: ''
       row:
         type: fields
         options:
+          default_field_elements: true
           inline: {  }
           separator: ''
           hide_empty: false
-          default_field_elements: true
-      access:
-        type: perm
-        options:
-          perm: 'view any webform submission'
-      filters:
-        in_draft:
-          id: in_draft
-          table: webform_submission
-          field: in_draft
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: All
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: 'Is draft'
-            description: ''
-            use_operator: false
-            operator: in_draft_op
-            identifier: in_draft
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: webform_submission
-          entity_field: in_draft
-          plugin_id: boolean
-        sticky:
-          id: sticky
-          table: webform_submission
-          field: sticky
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: All
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: Sticky
-            description: ''
-            use_operator: false
-            operator: sticky_op
-            identifier: sticky
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: webform_submission
-          entity_field: sticky
-          plugin_id: boolean
-        locked:
-          id: locked
-          table: webform_submission
-          field: locked
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: All
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: Locked
-            description: ''
-            use_operator: false
-            operator: locked_op
-            identifier: locked
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              demo_region: '0'
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: webform_submission
-          entity_field: locked
-          plugin_id: boolean
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
+      defaults:
+        access: false
+        style: false
+        row: false
+        fields: false
+        filters: false
+        filter_groups: false
+      display_description: 'Review submissions.'
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:

--- a/config/sync/webform.webform.contact.yml
+++ b/config/sync/webform.webform.contact.yml
@@ -7,9 +7,9 @@ dependencies:
       - webform
 _core:
   default_config_hash: _je-MWeeJB6gfm6iECiqjcyNetfMFbn-YIInYwZ1gIk
+weight: 0
 open: null
 close: null
-weight: 0
 uid: null
 template: false
 archive: false
@@ -56,9 +56,9 @@ settings:
   page_theme_name: ''
   form_title: source_entity_webform
   form_submit_once: false
-  form_exception_message: ''
   form_open_message: ''
   form_close_message: ''
+  form_exception_message: ''
   form_previous_submissions: true
   form_confidential: false
   form_confidential_message: ''
@@ -68,31 +68,36 @@ settings:
   form_prepopulate_source_entity: false
   form_prepopulate_source_entity_required: false
   form_prepopulate_source_entity_type: ''
-  form_reset: false
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
   form_disable_autocomplete: false
   form_novalidate: false
   form_disable_inline_errors: false
   form_required: false
-  form_unsaved: false
-  form_disable_back: false
-  form_submit_back: false
   form_autofocus: false
   form_details_toggle: false
+  form_reset: false
   form_access_denied: default
   form_access_denied_title: ''
   form_access_denied_message: ''
   form_access_denied_attributes: {  }
   form_file_limit: ''
+  form_attributes: {  }
   form_method: ''
   form_action: ''
-  form_attributes: {  }
   share: false
   share_node: false
   share_theme_name: ''
   share_title: true
   share_page_body_attributes: {  }
   submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
   submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
   submission_views: {  }
   submission_views_replace: {  }
   submission_user_columns: {  }
@@ -101,11 +106,6 @@ settings:
   submission_access_denied_title: ''
   submission_access_denied_message: ''
   submission_access_denied_attributes: {  }
-  submission_exception_message: ''
-  submission_locked_message: ''
-  submission_excluded_elements: {  }
-  submission_exclude_empty: false
-  submission_exclude_empty_checkbox: false
   previous_submission_message: ''
   previous_submissions_message: ''
   autofill: false
@@ -116,13 +116,13 @@ settings:
   wizard_progress_percentage: false
   wizard_progress_link: false
   wizard_progress_states: false
-  wizard_auto_forward: true
-  wizard_auto_forward_hide_next_button: false
-  wizard_keyboard: true
   wizard_start_label: ''
   wizard_preview_link: false
   wizard_confirmation: true
   wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
   wizard_track: ''
   wizard_prev_button_label: ''
   wizard_next_button_label: ''
@@ -147,9 +147,9 @@ settings:
   draft_pending_single_message: ''
   draft_pending_multiple_message: ''
   confirmation_type: url_message
+  confirmation_url: '<front>'
   confirmation_title: ''
   confirmation_message: 'Your message has been sent.'
-  confirmation_url: '<front>'
   confirmation_attributes: {  }
   confirmation_back: true
   confirmation_back_label: ''
@@ -228,9 +228,9 @@ access:
 handlers:
   email_confirmation:
     id: email
+    handler_id: email_confirmation
     label: 'Email confirmation'
     notes: ''
-    handler_id: email_confirmation
     status: true
     conditions: {  }
     weight: 1
@@ -239,13 +239,17 @@ handlers:
         - completed
       to_mail: '[current-user:mail]'
       to_options: {  }
-      cc_mail: ''
-      cc_options: {  }
       bcc_mail: ''
       bcc_options: {  }
+      cc_mail: ''
+      cc_options: {  }
       from_mail: _default
       from_options: {  }
       from_name: _default
+      reply_to: ''
+      return_path: ''
+      sender_mail: ''
+      sender_name: ''
       subject: '[webform_submission:values:subject:raw]'
       body: '[webform_submission:values:message:value]'
       excluded_elements: {  }
@@ -259,15 +263,11 @@ handlers:
       theme_name: ''
       parameters: {  }
       debug: false
-      reply_to: ''
-      return_path: ''
-      sender_mail: ''
-      sender_name: ''
   email_notification:
     id: email
+    handler_id: email_notification
     label: 'Email notification'
     notes: ''
-    handler_id: email_notification
     status: true
     conditions: {  }
     weight: 2
@@ -276,13 +276,17 @@ handlers:
         - completed
       to_mail: _default
       to_options: {  }
-      cc_mail: ''
-      cc_options: {  }
       bcc_mail: ''
       bcc_options: {  }
+      cc_mail: ''
+      cc_options: {  }
       from_mail: '[webform_submission:values:email:raw]'
       from_options: {  }
       from_name: '[webform_submission:values:name:raw]'
+      reply_to: ''
+      return_path: ''
+      sender_mail: ''
+      sender_name: ''
       subject: '[webform_submission:values:subject:raw]'
       body: '[webform_submission:values:message:value]'
       excluded_elements: {  }
@@ -296,8 +300,4 @@ handlers:
       theme_name: ''
       parameters: {  }
       debug: false
-      reply_to: ''
-      return_path: ''
-      sender_mail: ''
-      sender_name: ''
 variants: {  }


### PR DESCRIPTION
This PR introduces the "Categories" and "Provincies" taxonomy vocabulary, used to classify Location content items. 
Key changes include:

1. Creation of a new vocabulary called Categories
2. Insertion of predefined terms reflecting the UI tags on unlockbelgium.be
